### PR TITLE
feat: add transfer warning for single account users

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,6 +8,7 @@
 
 * **Coding Standards** Code should follow the PEP 8 coding standard.
 * **Dependency Management** This application uses Python Venv in the `venv` folder.
+* **Source Code** hosted on: https://github.com/danistrebel/gemini-bank
 
 ## Partial Code Overview
 
@@ -33,3 +34,5 @@ The UI is designed to be modern, accessible, and user-friendly, adhering to the 
     *   **High Contrast:** All text, icons, and UI elements are designed with sufficient color contrast against the background to meet WCAG 2.1 AA standards, ensuring readability for users with visual impairments.
     *   **Clear Focus States:** Interactive elements will have clear and visible focus indicators, making keyboard navigation straightforward.
     *   **Semantic HTML:** The application will use semantic HTML5 tags and ARIA (Accessible Rich Internet Applications) attributes where necessary to provide context to screen readers.
+
+

--- a/templates/transaction.html
+++ b/templates/transaction.html
@@ -15,7 +15,33 @@
   <div class="mb-3">
     {{ form.type.label(class="form-label") }}
     {{ form.type(class="form-control") }}
+    {% if user != "anonymous" and user.accounts.count() <= 1 %}
+    <div id="transfer-warning" class="alert alert-warning mt-2" style="display:none;">
+      Transfer is not possible since you have no other account to transfer to.
+    </div>
+    {% endif %}
   </div>
   {{ form.submit(class="btn btn-primary") }}
 </form>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    var typeSelect = document.getElementById('type');
+    var warningAlert = document.getElementById('transfer-warning');
+
+    if (typeSelect && warningAlert) {
+      function checkType() {
+        if (typeSelect.value === 'transfer') {
+          warningAlert.style.display = 'block';
+        } else {
+          warningAlert.style.display = 'none';
+        }
+      }
+
+      typeSelect.addEventListener('change', checkType);
+      // Run on initial load in case "transfer" was already selected (e.g. by browser history)
+      checkType();
+    }
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
This PR implements a warning message on the transaction page when a user selects "Transfer" but has only one account (or fewer).

Closes #1.

**Changes:**
- Added conditional rendering in `templates/transaction.html` to show an alert.
- Added JavaScript to toggle the alert based on the dropdown selection.
- Updated `GEMINI.md` with source code link.