### PR TITLE
Prevent negative balance on withdrawals

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -104,6 +104,9 @@ def transaction(id):
         if form.type.data == "deposit":
             transaction = Transaction(amount = amount_eur, type = form.type.data, description = form.description.data, account_id=id)
         else:
+            if account.balance < amount_eur:
+                flash(f"Insufficient funds for {form.type.data}. Current balance: {account.balance} EUR")
+                return redirect(url_for('transaction', id=id))
             transaction = Transaction(amount = -(amount_eur), type = form.type.data, description = form.description.data, account_id=id)
         db.session.add(transaction)
         account.balance += transaction.amount

--- a/routes.py
+++ b/routes.py
@@ -105,7 +105,7 @@ def transaction(id):
             transaction = Transaction(amount = amount_eur, type = form.type.data, description = form.description.data, account_id=id)
         else:
             if account.balance < amount_eur:
-                flash(f"Insufficient funds for {form.type.data}. Current balance: {account.balance} EUR")
+                flash(f"Insufficient funds for {form.type.data}. Current balance: {account.balance:.2f} EUR")
                 return redirect(url_for('transaction', id=id))
             transaction = Transaction(amount = -(amount_eur), type = form.type.data, description = form.description.data, account_id=id)
         db.session.add(transaction)


### PR DESCRIPTION
This PR implements a balance check for withdrawals to prevent accounts from having a negative balance.

Fixes #5.

Changes:
- Modified `transaction` route in `routes.py` to check if `account.balance >= withdrawal_amount` before processing the transaction.
- If funds are insufficient, an error message is flashed and the user is redirected back to the transaction page.